### PR TITLE
make "_get_feat_extract_output_lengths" easy to understand

### DIFF
--- a/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
+++ b/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
@@ -312,8 +312,7 @@ def _get_feat_extract_output_lengths(input_lengths):
     """
 
     input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+    output_lengths = (input_lengths_leave + 7) // 8 + (input_lengths // 100) * 13
     return output_lengths
 
 
@@ -1118,7 +1117,7 @@ class Qwen3ASRThinkerForConditionalGeneration(Qwen3ASRPreTrainedModelForConditio
         else:
             audio_feature_lengths = None
         feature_lens = audio_feature_lengths if audio_feature_lengths is not None else feature_attention_mask.sum(-1)
-    
+
         # audio encoder do not support batch inference to keep precision
         audio_features = []
         for input_feature, feature_len in zip(input_features, feature_lens):
@@ -1317,7 +1316,7 @@ class Qwen3ASRForConditionalGeneration(Qwen3ASRPreTrainedModel, GenerationMixin)
 
         self.thinker = Qwen3ASRThinkerForConditionalGeneration._from_config(config.thinker_config)
         self.post_init()
-    
+
     def get_support_languages(self):
         return self.config.support_languages
 

--- a/qwen_asr/core/transformers_backend/processing_qwen3_asr.py
+++ b/qwen_asr/core/transformers_backend/processing_qwen3_asr.py
@@ -42,8 +42,7 @@ def _get_feat_extract_output_lengths(input_lengths):
     """
 
     input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+    output_lengths = (input_lengths_leave + 7) // 8 + (input_lengths // 100) * 13
     return output_lengths
 
 

--- a/qwen_asr/core/vllm_backend/qwen3_asr.py
+++ b/qwen_asr/core/vllm_backend/qwen3_asr.py
@@ -114,10 +114,7 @@ logger = init_logger(__name__)
 
 def _get_feat_extract_output_lengths(input_lengths: torch.Tensor):
     input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = (
-        ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
-    )
+    output_lengths = (input_lengths_leave + 7) // 8 + (input_lengths // 100) * 13
     return output_lengths
 
 


### PR DESCRIPTION
This PR makes `_get_feat_extract_output_lengths()` easy to understand.

The same `_get_feat_extract_output_lengths` function is defined for 3 times and kept as it is.