### PR TITLE
Fix wrong project.urls (Homepage/Repository) in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ vllm = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Qwen/Qwen3-ASR"
-Repository = "https://github.com/Qwen/Qwen3-ASR"
+Homepage = "https://github.com/QwenLM/Qwen3-ASR"
+Repository = "https://github.com/QwenLM/Qwen3-ASR"
 
 [project.scripts]
 qwen-asr-demo = "qwen_asr.cli.demo:main"


### PR DESCRIPTION
pyproject.toml's [project.urls] currently points to https://github.com/Qwen/Qwen3-ASR, which is a 404.
Update Homepage/Repository to https://github.com/QwenLM/Qwen3-ASR.
[PyPI project links](https://pypi.org/project/qwen-asr/) are rendered from uploaded distribution metadata, so this will fix the links on PyPI after the next release is published. ￼