### PR TITLE
transformers>=4.57.3,<5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "Alibaba Qwen Team" }]
 
 dependencies = [
-  "transformers==4.57.6",
+  "transformers>=4.57.3,<5",
   "nagisa==0.2.11",
   "soynlp==0.0.493",
   "accelerate==1.12.0",


### PR DESCRIPTION
Related issue: https://github.com/QwenLM/Qwen3-ASR/issues/39

`qwen-asr` hard-pins `transformers==4.57.6`, preventing co-installation with `qwen-tts` despite verified compatibility.

This pull request makes the transformers dependency more flexible, allowing the installation of `qwen-tts` and `qwen-asr` in the same environment.

To confirm functionality:

```shell
pip install \
  git+https://github.com/joshuasundance-swca/Qwen3-ASR.git@transformers-pin \
  git+https://github.com/joshuasundance-swca/Qwen3-TTS.git@transformers-pin
```