### PR TITLE
fix: respect language parameter in vLLM transcription API

### DIFF
--- a/qwen_asr/core/vllm_backend/qwen3_asr.py
+++ b/qwen_asr/core/vllm_backend/qwen3_asr.py
@@ -977,8 +977,9 @@ class Qwen3ASRForConditionalGeneration(
                 f"Unsupported task_type '{task_type}'. "
                 "Supported task types are 'transcribe' and 'translate'."
             )
-        full_lang_name_to = cls.supported_languages.get(to_language, to_language)
-        if to_language is None:
+        effective_language = to_language or language
+        full_lang_name_to = cls.supported_languages.get(effective_language, effective_language)
+        if effective_language is None:
             prompt = (
                 f"<|im_start|>user\n{audio_placeholder}<|im_end|>\n"
                 f"<|im_start|>assistant\n"


### PR DESCRIPTION
When using the vLLM /v1/audio/transcriptions endpoint, the `language` parameter was ignored because `get_generation_prompt` only checked `to_language` and never fell back to `language`.

This adds a fallback so that when `to_language` is None, the `language` parameter is used instead, allowing the Whisper-compatible `language` field to correctly inject the language prefill into the assistant prompt.

Fixes: vllm-project/vllm#33768

## Testing

Tested with Qwen3-ASR-1.7B on vLLM serving (4 languages):

| Request | Before | After |
|---|---|---|
| `language=ko`, JA audio | ラインハルト、そなたが... | 라인 하르트, 소나타가 해보면 어때? |
| `language=ko`, KO audio | language Korean\<asr_text\>도움이... | 도움이 됐으면 좋겠군. |
| No language param | language Korean\<asr_text\>도움이... | (unchanged) |
