### PR TITLE
Fix Python dict syntax error in audio_url in vLLM Online Serving with OpenAI SDK example

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ response = client.chat.completions.create(
                 {
                     "type": "audio_url",
                     "audio_url": {
-                        {"url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"}
+                        "url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"
                     }
                 }
             ]


### PR DESCRIPTION
The Python example in README contains an invalid dictionary syntax:

```python
"audio_url": {
    {"url": "..."}
}
```
This creates a set containing a dictionary, which raises:

```
TypeError: unhashable type: ‘dict’
```

This PR fixes the example to the correct syntax:
```python
"audio_url": {
    "url": "..."
}
```
Tested locally with vLLM serving Qwen3-ASR-1.7B.