### PR TITLE
fix transformers 5.x API breaks

### DIFF
--- a/qwen_asr/core/transformers_backend/configuration_qwen3_asr.py
+++ b/qwen_asr/core/transformers_backend/configuration_qwen3_asr.py
@@ -321,6 +321,7 @@ class Qwen3ASRThinkerConfig(PretrainedConfig):
     model_type = "qwen3_asr_thinker"
 
     attribute_map = {}
+    pad_token_id = None
     sub_configs = {
         "audio_config": Qwen3ASRAudioEncoderConfig,
         "text_config": Qwen3ASRTextConfig,

--- a/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
+++ b/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
@@ -38,7 +38,13 @@ from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
 from transformers.utils import auto_docstring, can_return_tuple
 from transformers.utils.deprecation import deprecate_kwarg
-from transformers.utils.generic import TransformersKwargs, check_model_inputs
+from transformers.utils.generic import TransformersKwargs
+
+try:
+    from transformers.utils.generic import check_model_inputs
+except ImportError:
+    def check_model_inputs(func=None, **_kw):
+        return (lambda f: f) if func is None else func
 
 from .configuration_qwen3_asr import (
     Qwen3ASRAudioEncoderConfig,
@@ -791,13 +797,23 @@ class Qwen3ASRThinkerTextRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        if self.rope_type not in ROPE_INIT_FUNCTIONS:
+            self.rope_init_fn = self._compute_default_rope_parameters
+        else:
+            self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
 
         inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.original_inv_freq = self.inv_freq
 
         self.mrope_section = config.rope_scaling.get("mrope_section", [24, 20, 20])
+
+    @staticmethod
+    def _compute_default_rope_parameters(config, device=None, seq_len=None, **_kw):
+        base = getattr(config, "rope_theta", 10000.0)
+        dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32).to(device) / dim))
+        return inv_freq, 1.0
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.


### PR DESCRIPTION
Three API changes in transformers 5.x break qwen-asr with transformers >=5.0.

**1. check_model_inputs removed**

The decorator @check_model_inputs() was removed in transformers 5.x. The import raises ImportError at module load time, so qwen_asr cannot be imported at all with transformers 5.x.

Fix: guard the import with try/except and fall back to a transparent no-op decorator.

**2. ROPE_INIT_FUNCTIONS default key removed**

The default key was removed from ROPE_INIT_FUNCTIONS in transformers 5.x. Qwen3ASRThinkerTextRotaryEmbedding.__init__ indexes into it with self.rope_type which defaults to default, raising KeyError at model load time.

Fix: fall back to a self-contained RoPE parameter function when the key is missing. Also adds _compute_default_rope_parameters as a method, since the @dynamic_rope_update decorator in transformers 5.x calls it.

**3. pad_token_id missing on Qwen3ASRThinkerConfig**

GenerationMixin in transformers 5.x requires pad_token_id to be explicitly present on the config object. The attribute is not declared as a class-level default on Qwen3ASRThinkerConfig, causing AttributeError during generation.

Fix: declare pad_token_id = None as a class-level default.